### PR TITLE
Adding Zephyr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,8 +66,13 @@
     branch = blackparrot_mods
     ignore = untracked
 [submodule "yocto"]
-	path = yocto
+    path = yocto
     url = https://github.com/black-parrot-sdk/bp-yocto.git
+    branch = master
+    ignore = untracked
+[submodule "bp-zephyr"]
+    path = zephyr
+    url = https://github.com/black-parrot-sdk/bp-zephyr
     branch = master
     ignore = untracked
 
@@ -82,8 +87,7 @@
     branch = master
     ignore = untracked
 [submodule "spec2017"]
-	path = spec2017
-	url = https://github.com/black-parrot-sdk/spec2017.git
+    path = spec2017
+    url = https://github.com/black-parrot-sdk/spec2017.git
     branch = master
     ignore = untracked
-

--- a/Makefile.prog
+++ b/Makefile.prog
@@ -11,6 +11,7 @@ spec2017_dir    := $(BP_SDK_DIR)/spec2017
 riscvdv_dir     := $(BP_SDK_DIR)/riscv-dv
 linux_dir       := $(BP_SDK_DIR)/linux
 yocto_dir       := $(BP_SDK_DIR)/yocto
+zephyr_dir      := $(BP_SDK_DIR)/zephyr
 opcodes_dir     := $(BP_SDK_DIR)/riscv-opcodes
 
 define submodule_test_template
@@ -86,7 +87,10 @@ linux_build:
 yocto_build:
 	$(MAKE) -C $(yocto_dir) yocto.riscv
 
-.PHONY: perch bootrom bp-demos bp-tests riscv-tests beebs coremark spec2000 spec2006 riscv-dv linux yocto
+zephyr_build:
+	$(MAKE) -C $(zephyr_dir) all
+
+.PHONY: perch bootrom bp-demos bp-tests riscv-tests beebs coremark spec2000 spec2006 riscv-dv linux yocto zephyr
 $(eval $(call submodule_test_template,perch,$(perch_dir)))
 $(eval $(call submodule_test_template,bootrom,$(bootrom_dir)))
 $(eval $(call submodule_test_template,bp-demos,$(bp_demos_dir)))
@@ -100,6 +104,7 @@ $(eval $(call submodule_test_template,spec2017,$(spec2017_dir)))
 $(eval $(call submodule_test_template,riscv-dv,$(riscvdv_dir)))
 $(eval $(call submodule_test_template,linux,$(linux_dir)))
 $(eval $(call submodule_test_template,yocto,$(yocto_dir)))
+$(eval $(call submodule_test_template,zephyr,$(zephyr_dir)))
 
 .PHONY: prog_clean
 prog_clean:
@@ -118,3 +123,4 @@ prog_clean:
 	-$(MAKE) -C $(riscvdv_dir) clean
 	-$(MAKE) -C $(linux_dir) clean
 	-$(MAKE) -C $(yocto_dir) clean
+	-$(MAKE) -C $(zephyr_dir) clean


### PR DESCRIPTION
This PR tracks the zephyr integration at https://github.com/black-parrot-sdk/bp-zephyr/tree/master

Unsolved issues:
- [ ] Multicore (https://github.com/zephyrproject-rtos/zephyr/issues/16814)
- [ ] PLIC (there's currently a hack to disable the initialization code
- [ ] UART driver untested for getchar
- [ ] Other device drivers / dts configurations?
- [ ] A zephyr application wrapper for generic BP apps (e.g. run Parsec as a Zephyr app)
