### PR TITLE
rework shallow cloning - disable by default for tools due to qemu

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -30,5 +30,9 @@ export CROSS_COMPILE ?= $(RISCV_TARGET)-
 
 export PATH := $(BP_SDK_BIN_DIR):$(PATH)
 
-# Makes clones much faster. Comment out if you see "fatal: reference is not a tree"
-SHALLOW_SUB ?= --depth=1
+# Makes clones much faster. Comment out if you see an error while cloning submodules
+export SDK_SHALLOW ?= --depth=1
+export SDK_PROGS_SHALLOW ?= --depth=1
+# riscv-gnu-toolchain/qemu doesn't work well with a shallow clone, enable if you
+# want to give it a try
+#export SDK_TOOLS_SHALLOW ?= --depth=1

--- a/Makefile.common
+++ b/Makefile.common
@@ -31,8 +31,6 @@ export CROSS_COMPILE ?= $(RISCV_TARGET)-
 export PATH := $(BP_SDK_BIN_DIR):$(PATH)
 
 # Makes clones much faster. Comment out if you see an error while cloning submodules
-export SDK_SHALLOW ?= --depth=1
-export SDK_PROGS_SHALLOW ?= --depth=1
-# riscv-gnu-toolchain/qemu doesn't work well with a shallow clone, enable if you
-# want to give it a try
-#export SDK_TOOLS_SHALLOW ?= --depth=1
+# riscv-gnu-toolchain/qemu doesn't work well with a shallow clone, try setting this
+# flag to --depth=1 if you want to give it a try.
+export SDK_SHALLOW ?=

--- a/Makefile.prog
+++ b/Makefile.prog
@@ -13,7 +13,7 @@ define submodule_test_template
 $(1)_tag ?= $(addprefix $(1)., $(shell cd $(2); git rev-parse HEAD))
 $(BP_TOUCH_DIR)/$$($(1)_tag):
 	rm -rf $(BP_TOUCH_DIR)/$(1).*
-	cd $(BP_SDK_DIR); git submodule update --init --merge --recursive $(SDK_PROGS_SHALLOW) -- $$($(1)_dir)
+	cd $(BP_SDK_DIR); git submodule update --init --merge --recursive $(SDK_SHALLOW) -- $$($(1)_dir)
 	+$(MAKE) $(1)_build
 	mkdir -p $(BP_PROG_DIR)/$(1)
 	find $(2) -name "*.riscv" -exec cp {} $(BP_PROG_DIR)/$(1)/ \;

--- a/Makefile.prog
+++ b/Makefile.prog
@@ -1,5 +1,3 @@
-include $(BP_SDK_DIR)/Makefile.common
-
 perch_dir       := $(BP_SDK_DIR)/perch
 bootrom_dir     := $(BP_SDK_DIR)/bootrom
 bp_demos_dir    := $(BP_SDK_DIR)/bp-demos
@@ -15,7 +13,7 @@ define submodule_test_template
 $(1)_tag ?= $(addprefix $(1)., $(shell cd $(2); git rev-parse HEAD))
 $(BP_TOUCH_DIR)/$$($(1)_tag):
 	rm -rf $(BP_TOUCH_DIR)/$(1).*
-	cd $(BP_SDK_DIR); git submodule update --init --merge $(SHALLOW_SUB) --recursive $$($(1)_dir)
+	cd $(BP_SDK_DIR); git submodule update --init --merge --recursive $(SDK_PROGS_SHALLOW) -- $$($(1)_dir)
 	+$(MAKE) $(1)_build
 	mkdir -p $(BP_PROG_DIR)/$(1)
 	find $(2) -name "*.riscv" -exec cp {} $(BP_PROG_DIR)/$(1)/ \;
@@ -37,10 +35,10 @@ $(BP_LIB_DIR)/libperch.a $(BP_LIB_DIR)/crt0.o:
 	cp $(perch_dir)/*.h $(BP_INCLUDE_DIR)
 
 bootrom_build:
-	$(MAKE) -C $(bootrom_dir)
+	$(MAKE) -C $(bootrom_dir) clean all
 
 bp-demos_build:
-	$(MAKE) -C $(bp_demos_dir)
+	$(MAKE) -C $(bp_demos_dir) clean all
 
 bp-tests_build:
 	$(MAKE) -C $(bp_tests_dir) clean all
@@ -83,3 +81,16 @@ $(eval $(call submodule_test_template,spec2000,$(spec2000_dir)))
 $(eval $(call submodule_test_template,riscv-dv,$(riscvdv_dir)))
 $(eval $(call submodule_test_template,linux,$(linux_dir)))
 
+.PHONY: prog_clean
+prog_clean:
+	rm -rf $(BP_PROG_DIR)
+	-$(MAKE) -C $(perch_dir) clean
+	-$(MAKE) -C $(bootrom_dir) clean
+	-$(MAKE) -C $(bp_demos_dir) clean
+	-$(MAKE) -C $(bp_tests_dir) clean
+	-$(MAKE) -C $(riscv_tests_dir) clean
+	-$(MAKE) -C $(beebs_dir) clean
+	-$(MAKE) -C $(coremark_dir) clean
+	-$(MAKE) -C $(spec2000_dir) clean
+	-$(MAKE) -C $(riscvdv_dir) clean
+	-$(MAKE) -C $(linux_dir) clean

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -6,7 +6,7 @@ define submodule_tool_template
 $(1)_tag ?= $(addprefix $(1)., $(shell cd $(2); git rev-parse HEAD))
 $(BP_SDK_TOUCH_DIR)/$$($(1)_tag):
 	rm -rf $(BP_SDK_TOUCH_DIR)/$(1).*
-	cd $(BP_SDK_DIR); git submodule update --init --recursive --checkout $(SDK_TOOLS_SHALLOW) -- $$($(1)_dir)
+	cd $(BP_SDK_DIR); git submodule update --init --recursive --checkout $(SDK_SHALLOW) -- $$($(1)_dir)
 	+$(MAKE) $(1)_build
 	touch $(BP_SDK_TOUCH_DIR)/$$($(1)_tag)
 $(1): | $(BP_SDK_TOUCH_DIR)/$$($(1)_tag)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -6,7 +6,7 @@ define submodule_tool_template
 $(1)_tag ?= $(addprefix $(1)., $(shell cd $(2); git rev-parse HEAD))
 $(BP_SDK_TOUCH_DIR)/$$($(1)_tag):
 	rm -rf $(BP_SDK_TOUCH_DIR)/$(1).*
-	cd $(BP_SDK_DIR); git submodule update --init $(SHALLOW_SUB) --recursive --checkout $$($(1)_dir)
+	cd $(BP_SDK_DIR); git submodule update --init --recursive --checkout $(SDK_TOOLS_SHALLOW) -- $$($(1)_dir)
 	+$(MAKE) $(1)_build
 	touch $(BP_SDK_TOUCH_DIR)/$$($(1)_tag)
 $(1): | $(BP_SDK_TOUCH_DIR)/$$($(1)_tag)
@@ -37,12 +37,13 @@ bedrock_build:
 	cp $(bedrock_dir)/roms/*.addr $(BP_UCODE_DIR)/
 	cp $(bedrock_dir)/roms/*.mem $(BP_UCODE_DIR)/
 
+.PHONY: gnu dromajo bedrock
 $(eval $(call submodule_tool_template,gnu,$(gnu_dir)))
 $(eval $(call submodule_tool_template,dromajo,$(dromajo_dir)))
 $(eval $(call submodule_tool_template,bedrock,$(bedrock_dir)))
 
-# This target cleans up the sdk build directories, saving significant space
-tidy_sdk:
-	cd $(BP_SDK_DIR); git submodule deinit -f $(gnu_dir)
-	cd $(BP_SDK_DIR); git submodule deinit -f $(dromajo_dir)
-
+.PHONY: tools_clean
+tools_clean:
+	-$(MAKE) -C $(bedrock_dir) clean
+	-$(MAKE) -C $(dromajo_dir)/build clean
+	-$(MAKE) -C $(gnu_dir) clean

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ programs are missing or too old: make" try
 
     sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev wget byacc device-tree-compiler python gtkwave vim-common virtualenv python-yaml
 
-cmake3 is required. This is the default on newer versions of Ubuntu, but not necessarily on old versions. 
+cmake3 is required. This is the default on newer versions of Ubuntu, but not necessarily on old versions.
 
 BlackParrot has been tested extensively on CentOS 7. We have many users who have used Ubuntu for
 development. If not on these versions of these OSes, we suggest using a
@@ -33,6 +33,7 @@ Ubuntu on Windows WSL 2.0 seems to work for most things, but you may encounter e
 
 ### Building the SDK
 
+    make checkout # initialize submodules
     make sdk  # you can use the -j N flag to parallelize
     make prog # only makes a subset of programs. See Makefile for the full list of commands
 
@@ -66,18 +67,18 @@ to the filesystem using normal calls:
     int main() {
         // Initialize LFS
         dramfs_init();
-    
+
         // Read from a file
         FILE *hello = fopen("hello.txt", "r");
         if(hello == NULL)
           return -1;
-    
+
         char c;
         while((c = fgetc(hello)) != '\n') {
           bp_cprint(c);
         }
         bp_cprint('\n');
-    
+
         fclose(hello);
         bp_finish(0);
         return 0;
@@ -122,7 +123,7 @@ Dromajo in that repo.
     ./install/bin/dromajo --host [--enable_amo] [--ncpus=1] [--trace] ./prog/custom/foobar.riscv
 
 will run your program. The --host options make Dromajo behave as BlackParrot, with a host interface
-emulating our Verilog testbench. Once Dromajo passes your test, you're ready to run on BlackParrot! 
+emulating our Verilog testbench. Once Dromajo passes your test, you're ready to run on BlackParrot!
 
 ### Debugging your test
 Dromajo supports tracing. This option is enabled by adding --trace=0 to the dromajo invocation (0 indicates to start the trace after 0 instructions). The trace format is:


### PR DESCRIPTION
This should address the issues seen when cloning tools, specifically riscv-gnu-toolchain/qemu.

The flag to shallow clone exists as a placeholder and can be set via command line or in Makefile.common