### PR TITLE
Add binary releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+image: ubuntu:20.04
+
+variables:
+  GIT_DEPTH: 0
+
+release:
+  script:  
+    - apt update
+    - DEBIAN_FRONTEND="noninteractive" apt install -y git autoconf automake autotools-dev cmake curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev wget byacc device-tree-compiler python gtkwave vim-common virtualenv python-yaml
+    - mkdir dist
+    - make sdk_lite -j$(nproc)
+    - tar -czvf dist/sdk_lite.tgz ucode install lib include
+    - make sdk -j$(nproc)
+    - tar -czvf dist/sdk.tgz ucode install lib include
+    - apt update
+    - apt install -y software-properties-common
+    - apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+    - apt-add-repository https://cli.github.com/packages
+    - apt update
+    - apt install -y gh
+    - gh config set prompt disabled
+    - gh release create $CI_COMMIT_TAG ./dist/*.tgz --repo developandplay/black-parrot-sdk
+  only:
+    - tags
+  timeout: 3 hours

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ $(TARGET_DIRS):
 checkout:
 	cd $(BP_SDK_DIR); git submodule update --init --checkout $(SDK_SHALLOW)
 
+	
+pull_sdk_lite: cd $(BP_SDK_DIR); curl -L $(git config --get remote.origin.url)/releases/download/$(git describe --tags --abbrev=0)/sdk_lite.tgz | tar -xvz
+
+pull_sdk: cd $(BP_SDK_DIR); curl -L $(git config --get remote.origin.url)/releases/download/$(git describe --tags --abbrev=0)/sdk.tgz | tar -xvz
+
 sdk_lite: | $(TARGET_DIRS)
 	$(MAKE) -j1 bedrock
 	$(MAKE) dromajo


### PR DESCRIPTION
Just saw that #7 is still open but has gone stale.

This is the updated version based on current master and @dpetrisko s review of #7 .
Binaries can be viewed on https://github.com/developandplay/black-parrot-sdk/releases/tag/v.0.0.1.

Steps to use:

1. Create Gitlab mirror of black-parrot-sdk
2. Create custom runner with enough compute and storage in Gitlab (4core CPU, 16gb RAM, 50gb SSD was what I used)
3. Create protected tags for `v*` releases in Gitlab
4. Get `$GITHUB_TOKEN` from Github and enter it as CI variable in Gitlab
5. Change `gh release create $CI_COMMIT_TAG ./dist/*.tgz --repo developandplay/black-parrot-sdk` in `gitlab-ci.yml` l.22 to `gh release create $CI_COMMIT_TAG ./dist/*.tgz --repo black-parrot-sdk/black-parrot-sdk`.
6. To release a binary just create a new tag `v*`

Changes from #7 to this PR:

1. Build and release are now one stage since the artifacts are too large for gitlab to pass between stages.
2. `prog` is not part of the binary anymore based on review feedback on #7.
3. `ucode` is now in both binaries because `bedrock` is part of `sdk_lite` as of 28760ecd9097dfd457e55935546ddf510048f040
4. `lib` and is now explicitly mentioned since it was moved from `install/lib` to `lib` in 965da450475f4b632559f330a0c0c735b3d80486. Same applies to `include`.
5. Makefiles are not modified like in #7 instead `pull_sdk` and `pull_sdk_lite` are added