### PR TITLE
[WIP] LLVM support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,12 @@ build_gnu:
     - make gnudramfs -j ${CI_NUM_CORES} | tee gnudramfs.log
     - make gnulinux -j ${CI_NUM_CORES} | tee gnulinux.log
 
+build_llvm:
+  <<: *job_definition
+  stage: tools
+  script:
+    - make llvm -j ${CI_NUM_CORES} | tee llvm.log
+
 build_perch:
   <<: *job_definition
   stage: perch
@@ -108,6 +114,7 @@ zip_tools:
     - build_bedrock
     - build_dromajo
     - build_gnu
+    - build_llvm
 
 zip_prog:
   stage: zip

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,6 +3,11 @@
     url = https://github.com/black-parrot-sdk/riscv-gnu-toolchain
     branch = blackparrot_mods
     ignore = untracked
+[submodule "llvm-project"]
+	path = llvm-project
+	url = https://github.com/black-parrot-sdk/llvm-project
+    branch = blackparrot_mods
+    ignore = untracked
 [submodule "dromajo"]
     path = dromajo
     url = https://github.com/bsg-external/dromajo
@@ -80,5 +85,8 @@
     branch = master
     ignore = untracked
 [submodule "spec2017"]
-	path = spec2017
-	url = https://github.com/black-parrot-sdk/spec2017.git
+    path = spec2017
+    url = https://github.com/black-parrot-sdk/spec2017.git
+    branch = master
+    ignore = untracked
+

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -1,6 +1,7 @@
 gnu_dir      :=$(BP_SDK_DIR)/riscv-gnu-toolchain
 gnudramfs_dir:=$(gnu_dir)
 gnulinux_dir :=$(gnu_dir)
+llvm_dir     :=$(BP_SDK_DIR)/llvm-project
 dromajo_dir  :=$(BP_SDK_DIR)/dromajo
 bedrock_dir  :=$(BP_SDK_DIR)/bedrock
 
@@ -33,6 +34,20 @@ gnudramfs_build:
 	$(MAKE) -C $(gnu_dir) install
 	cp $(BP_SDK_INSTALL_DIR)/riscv64-unknown-elf-dramfs/bin/dramfs_mklfs $(BP_SDK_BIN_DIR)
 
+llvm_build:
+	cd $(llvm_dir); \
+		$(CMAKE) -S llvm -B build -G "Ninja" \
+		-DLLVM_ENABLE_PROJECTS=clang \
+		-DBUILD_SHARED_LIBS=True \
+		-DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+		-DLLVM_TARGETS_TO_BUILD="RISCV" \
+		-DCMAKE_INSTALL_PREFIX=$(BP_SDK_INSTALL_DIR) \
+		-DCMAKE_BUILD_TYPE=Release
+	cd $(llvm_dir); \
+		$(CMAKE) --build build
+	cd $(llvm_dir); \
+		$(CMAKE) --build build --target install
+
 dromajo_build:
 	mkdir -p $(dromajo_dir)/build
 	$(CMAKE) -S $(dromajo_dir) -B $(dromajo_dir)/build -DCMAKE_BUILD_TYPE=Release
@@ -51,6 +66,7 @@ bedrock_build:
 .PHONY: gnu dromajo bedrock panic_room
 $(eval $(call submodule_tool_template,gnudramfs,$(gnudramfs_dir)))
 $(eval $(call submodule_tool_template,gnulinux,$(gnulinux_dir)))
+$(eval $(call submodule_tool_template,llvm,$(llvm_dir)))
 $(eval $(call submodule_tool_template,dromajo,$(dromajo_dir)))
 $(eval $(call submodule_tool_template,bedrock,$(bedrock_dir)))
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y autoconf automake libmpc-devel mpfr-devel gmp-devel gawk  bis
 RUN yum install -y epel-release
 RUN rpm -U https://repo.ius.io/ius-release-el7.rpm
 RUN yum install -y git224
-RUN yum install -y cmake3
+RUN yum install -y cmake3 ninja-build
 # Install github CLI
 RUN yum install -y wget
 RUN wget https://github.com/cli/cli/releases/download/v1.12.1/gh_1.12.1_linux_amd64.rpm

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,3 +8,5 @@ build:
 push: build
 	docker push registry.gitlab.com/dpetrisko/black-parrot-sdk
 
+run:
+	docker run -it registry.gitlab.com/dpetrisko/black-parrot-sdk


### PR DESCRIPTION
This WIP PR adds support for LLVM to the SDK. The biggest problem here is that LLVM Is huge (several GB), so the clone takes a long time. Possibly it makes sense to "clone" it as a zip download, (also might make sense for riscv-gnu-toolchain)