### PR TITLE
Bump dromajo to revert commit failing CI

### DIFF
--- a/Makefile.platform
+++ b/Makefile.platform
@@ -3,7 +3,7 @@ PLATFORM ?= dromajo_cosim
 
 ifeq ($(PLATFORM),dromajo_cosim)
 PLATFORM_DRAM_BASE ?= 0x80000000
-PLATFORM_SP        ?= 0x81000000
+PLATFORM_SP        ?= 0x8F000000
 else ifeq ($(PLATFORM),zynqparrot)
 PLATFORM_DRAM_BASE ?= 0x80000000
 PLATFORM_SP        ?= 0x877FF000


### PR DESCRIPTION
This commit reverts a commit in Dromajo that causes CI to fail. This PR should be merged alongside https://github.com/black-parrot/black-parrot/pull/915 or https://github.com/black-parrot/black-parrot/pull/920