### PR TITLE
Add Yocto Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "spec2017"]
 	path = spec2017
 	url = https://github.com/black-parrot-sdk/spec2017.git
+[submodule "yocto"]
+	path = yocto
+	url = https://github.com/collinmay/bp-yocto.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -84,4 +84,4 @@
 	url = https://github.com/black-parrot-sdk/spec2017.git
 [submodule "yocto"]
 	path = yocto
-	url = https://github.com/collinmay/bp-yocto.git
+	url = https://github.com/black-parrot-sdk/bp-yocto.git

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ prog: prog_lite
 	#$(MAKE) riscv-dv
 	# Requires patience
 	#$(MAKE) linux
+	# Requires even more patience
+	#$(MAKE) yocto
 
 sdk_clean:
 	-$(MAKE) prog_clean

--- a/Makefile.prog
+++ b/Makefile.prog
@@ -10,6 +10,7 @@ spec2006_dir    := $(BP_SDK_DIR)/spec2006
 spec2017_dir    := $(BP_SDK_DIR)/spec2017
 riscvdv_dir     := $(BP_SDK_DIR)/riscv-dv
 linux_dir       := $(BP_SDK_DIR)/linux
+yocto_dir       := $(BP_SDK_DIR)/yocto
 opcodes_dir     := $(BP_SDK_DIR)/riscv-opcodes
 
 define submodule_test_template
@@ -81,7 +82,10 @@ WITH_SHELL    ?= $(linux_dir)/cfg/test.sh
 linux_build:
 	$(MAKE) -C $(linux_dir) linux.riscv OPENSBI_NCPUS=$(OPENSBI_NCPUS) WITH_SHELL=$(WITH_SHELL)
 
-.PHONY: perch bootrom bp-demos bp-tests riscv-tests beebs coremark spec2000 spec2006 riscv-dv linux
+yocto_build:
+	$(MAKE) -C $(yocto_dir) yocto.riscv
+
+.PHONY: perch bootrom bp-demos bp-tests riscv-tests beebs coremark spec2000 spec2006 riscv-dv linux yocto
 $(eval $(call submodule_test_template,perch,$(perch_dir)))
 $(eval $(call submodule_test_template,bootrom,$(bootrom_dir)))
 $(eval $(call submodule_test_template,bp-demos,$(bp_demos_dir)))
@@ -94,6 +98,7 @@ $(eval $(call submodule_test_template,spec2006,$(spec2006_dir)))
 $(eval $(call submodule_test_template,spec2017,$(spec2017_dir)))
 $(eval $(call submodule_test_template,riscv-dv,$(riscvdv_dir)))
 $(eval $(call submodule_test_template,linux,$(linux_dir)))
+$(eval $(call submodule_test_template,yocto,$(yocto_dir)))
 
 .PHONY: prog_clean
 prog_clean:
@@ -111,3 +116,4 @@ prog_clean:
 	-$(MAKE) -C $(spec2017_dir) clean
 	-$(MAKE) -C $(riscvdv_dir) clean
 	-$(MAKE) -C $(linux_dir) clean
+	-$(MAKE) -C $(yocto_dir) clean


### PR DESCRIPTION
Like the title says. This is much like the buildroot-based Linux build, but using Yocto instead and has some more packages included. It also uses a physmem-backed virtual mtd device for rootfs instead of initramfs like buildroot Linux. This runs under Dromajo. As I write this, I'm patiently waiting to see whether it boots under RTL testbench or not.