### PR TITLE
Adding riscv-arch-test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,11 @@
     url = https://github.com/black-parrot-sdk/spec2017.git
     branch = master
     ignore = untracked
+[submodule "bp-riscv-arch-test"]
+    path = riscv-arch-test
+    url = https://github.com/black-parrot-sdk/bp-riscv-arch-test.git
+    branch = master
+    ignore = untracked
 
 # BlackParrot wrappers for OSes
 [submodule "bp-zephyr"]

--- a/Makefile.prog
+++ b/Makefile.prog
@@ -13,6 +13,7 @@ linux_dir       := $(BP_SDK_DIR)/linux
 yocto_dir       := $(BP_SDK_DIR)/yocto
 zephyr_dir      := $(BP_SDK_DIR)/zephyr
 opcodes_dir     := $(BP_SDK_DIR)/riscv-opcodes
+riscv_arch_dir  := $(BP_SDK_DIR)/riscv-arch-test
 
 define submodule_test_template
 .PHONY: $(1)
@@ -94,6 +95,11 @@ riscv-dv_build:
 		do [ -f "$$f" ] && $(MV) "$$f" "$${f$(PERCENT)o}riscv"; \
 	done
 
+riscv-arch_build:
+	$(MAKE) -C $(riscv_arch_dir) all
+	$(FIND) $(riscv_arch_dir)/work/riscof -name "*-01.riscv" -exec $(MV) {} $(BP_SDK_PROG_DIR)/riscv-arch/ \;
+	$(FIND) $(riscv_arch_dir)/work/riscof -name "*-01.signature" -exec $(MV) {} $(BP_SDK_PROG_DIR)/riscv-arch/ \;
+
 # Default Linux build is single core and terminates immediately
 OPENSBI_NCPUS ?= 1
 WITH_SHELL    ?= $(linux_dir)/cfg/test_info.sh
@@ -112,6 +118,7 @@ $(eval $(call submodule_test_template,bootrom,$(bootrom_dir)))
 $(eval $(call submodule_test_template,bp-demos,$(bp_demos_dir)))
 $(eval $(call submodule_test_template,bp-tests,$(bp_tests_dir)))
 $(eval $(call submodule_test_template,riscv-tests,$(riscv_tests_dir)))
+$(eval $(call submodule_test_template,riscv-arch,$(riscv_arch_dir)))
 $(eval $(call submodule_test_template,beebs,$(beebs_dir)))
 $(eval $(call submodule_test_template,coremark,$(coremark_dir)))
 $(eval $(call submodule_test_template,spec2000,$(spec2000_dir)))
@@ -140,3 +147,4 @@ prog_clean:
 	-$(MAKE) -C $(linux_dir) clean
 	-$(MAKE) -C $(yocto_dir) clean
 	-$(MAKE) -C $(zephyr_dir) clean
+

--- a/patches/riscv-gnu-toolchain/pk/0001-config.patch
+++ b/patches/riscv-gnu-toolchain/pk/0001-config.patch
@@ -1,0 +1,28 @@
+diff --git a/scripts/config.sub b/scripts/config.sub
+index 9ccf09a..efca0cd 100755
+--- a/scripts/config.sub
++++ b/scripts/config.sub
+@@ -361,10 +361,10 @@ case $basic_machine in
+ 	  basic_machine=$basic_machine-pc
+ 	  ;;
+ 	# Object if more than one company name word.
+-	*-*-*)
+-		echo Invalid configuration \`"$1"\': machine \`"$basic_machine"\' not recognized 1>&2
+-		exit 1
+-		;;
++	#*-*-*)
++	#	echo Invalid test configuration0 \`"$1"\': machine \`"$basic_machine"\' not recognized 1>&2
++	#	exit 1
++	#	;;
+ 	# Recognize the basic CPU types with company name.
+ 	580-* \
+ 	| a29k-* \
+@@ -1524,6 +1524,8 @@ case $os in
+ 		;;
+ 	-none)
+ 		;;
++    -dramfs)
++        ;;
+ 	*)
+ 		# Get rid of the `-' at the beginning of $os.
+ 		os=`echo $os | sed 's/[^-]*-//'`


### PR DESCRIPTION
This PR adds support for https://github.com/riscv-non-isa/riscv-arch-test, which is the official architectural testing framework for RISC-V