### PR TITLE
ci: include interrupt-priority tests in smoke-bp-tests

### DIFF
--- a/ci/smoke-bp-tests.sh
+++ b/ci/smoke-bp-tests.sh
@@ -4,7 +4,7 @@ source $(dirname $0)/functions.sh
 sim=$1; shift
 
 suite=bp-tests
-progs=(amo_nonblocking cache_flush cache_hammer constructor divide_hazard dram_stress fflags_haz fp_neg_zero_nanbox fp_precision hello_world loop mapping map mstatus_fs nanboxing paging satp_nofence stream_hammer template timer_interrupt unwinding vector virtual)
+progs=(amo_nonblocking cache_flush cache_hammer constructor divide_hazard dram_stress fflags_haz fp_neg_zero_nanbox fp_precision hello_world loop mapping map mstatus_fs nanboxing paging satp_nofence stream_hammer template timer_interrupt interrupt_priority interrupt_priority_simultaneous interrupt_priority_race unwinding vector virtual)
 
 for prog in "${progs[@]}"; do
     do_single_sim ${sim} ${suite} ${prog} 1


### PR DESCRIPTION
Related: black-parrot/black-parrot#1287

## Summary:
  - Add interrupt_priority to smoke-bp-tests
  - Add interrupt_priority_simultaneous to smoke-bp-tests
  - Add interrupt_priority_race to smoke-bp-tests

## Note:
  - This PR depends on bp-tests PR adding the new test sources.